### PR TITLE
bluebinder: support reading the bluetooth address from persist.vendor.service.bdroid.bdaddr.

### DIFF
--- a/bluebinder_wait.sh
+++ b/bluebinder_wait.sh
@@ -24,6 +24,12 @@ do
             chown root:root /var/lib/bluetooth/board-address
             chmod 644 /var/lib/bluetooth/board-address
             exit 0
+        elif [ "$(getprop persist.vendor.service.bdroid.bdaddr)" != "" ]; then
+            mkdir -p /var/lib/bluetooth
+            echo $(getprop persist.vendor.service.bdroid.bdaddr |awk -F: '{do printf "%s"(NF>1?FS:RS),$NF;while(--NF)}') > /var/lib/bluetooth/board-address
+            chown root:root /var/lib/bluetooth/board-address
+            chmod 644 /var/lib/bluetooth/board-address
+            exit 0
         else
             echo "Failed to get bluetooth address."
             exit 1

--- a/rpm/bluebinder.spec
+++ b/rpm/bluebinder.spec
@@ -11,6 +11,7 @@ Source:         %{name}-%{version}.tar.bz2
 BuildRequires:  libgbinder-devel >= 1.0.7
 BuildRequires:  pkgconfig(bluez5)
 BuildRequires:  pkgconfig(libsystemd)
+Requires:       gawk
 Requires:       bluez5
 Requires:       /usr/bin/getprop
 


### PR DESCRIPTION
[bluebinder] support reading the bluetooth address from persist.vendor.service.bdroid.bdaddr. JB#47840