### PR TITLE
bluebinder: gbinder reader expects gsize for size and count

### DIFF
--- a/bluebinder.c
+++ b/bluebinder.c
@@ -416,7 +416,7 @@ bluebinder_callbacks_transact(
             }
 
         } else if (code == 2 || code == 3 || code == 4) {
-            unsigned int count, elemsize;
+            gsize count, elemsize;
             GBinderReader reader;
             const uint8_t *vec;
             uint8_t *packet;


### PR DESCRIPTION
Fixes compile warnings