### PR TITLE
bluebinder: Make linking against systemd optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 # TODO: this is a bit minimalistic isn't it?
 
+USE_SYSTEMD ?= 1
+
+DEPEND_LIBS = libgbinder glib-2.0
+ifeq ($(USE_SYSTEMD),1)
+DEPEND_LIBS += libsystemd
+endif
+
 build: bluebinder
 
 bluebinder: bluebinder.c
-	gcc $(CFLAGS) -Wall -flto $^ `pkg-config --cflags --libs libgbinder glib-2.0 libsystemd` -o $@
+	gcc $(CFLAGS) -Wall -flto $^ `pkg-config --cflags --libs $(DEPEND_LIBS)` -DUSE_SYSTEMD=$(USE_SYSTEMD) -o $@
 
 install:
 	mkdir -p $(DESTDIR)/usr/sbin

--- a/bluebinder.c
+++ b/bluebinder.c
@@ -39,7 +39,9 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 
+#if USE_SYSTEMD
 #include <systemd/sd-daemon.h>
+#endif
 
 #include <gbinder.h>
 
@@ -406,7 +408,9 @@ bluebinder_callbacks_transact(
 
             if (binder_init_complete(proxy)) {
                 proxy->init_failed = FALSE;
+#if USE_SYSTEMD
                 sd_notify(0, "READY=1");
+#endif
                 *status = GBINDER_STATUS_OK;
                 return gbinder_local_reply_append_int32(gbinder_local_object_new_reply(obj), 0);
             } else {
@@ -574,9 +578,11 @@ unref:
 
     close(proxy.host_fd);
 
+#if USE_SYSTEMD
     sd_notify(0,
         "STATUS=Exiting.\n"
         "ERRNO=19");
+#endif
 
     return err;
 }


### PR DESCRIPTION
This allows the package to be built and used on distributions that do not ship systemd as their init system by setting the `USE_SYSTEMD` flag to 0 in the Makefile.

Tests:
```
$ make
...
$ strings bluebinder | grep READY
READY=1
$ ldd bluebinder | grep systemd
	libsystemd.so.0 => /usr/lib/libsystemd.so.0 (0x00007f7a75f1e000)
$ make clean
rm bluebinder

$ make USE_SYSTEMD=0
...
$ strings bluebinder | grep READY
$ ldd bluebinder | grep systemd
```