### PR TITLE
wait: Check for versioned bluetooth service

### DIFF
--- a/bluebinder_wait.sh
+++ b/bluebinder_wait.sh
@@ -2,7 +2,7 @@
 
 while true
 do
-    bt_status=$(/usr/bin/getprop |grep "init.svc.*bluetooth" |grep -o "\[running\]")
+    bt_status=$(/usr/bin/getprop |grep "init.svc.*bluetooth\|init.svc.*bluetooth-1-0" | grep -o "\[running\]" | uniq)
     if [ "$bt_status" = "[running]" ] ; then
         echo "Bluetooth service running"
         exit 0


### PR DESCRIPTION
On the JingPad the vendor service on the Halium side has a version
number appended on the service identifier.
Accommodate for that to fix Bluebinder on the JingPad.

Reference: https://github.com/ubports/bluebinder/pull/5