### PR TITLE
post: Also check for vendor btaddr property

### DIFF
--- a/bluebinder_post.sh
+++ b/bluebinder_post.sh
@@ -14,9 +14,15 @@ mkdir -p /var/lib/bluetooth
 
 # Getting address file from properties
 bt_addr_file=$(/usr/bin/getprop ro.bt.bdaddr_path)
+bt_addr_vendor_file=$(/usr/bin/getprop ro.vendor.bt.bdaddr_path)
 if [ "$bt_addr_file" != "" ]; then
     if ! cp $bt_addr_file /var/lib/bluetooth/board-address; then
         echo "Failed to copy $bt_addr_file."
+        exit 1
+    fi
+elif [ "$bt_addr_vendor_file" != "" ]; then
+    if ! cp $bt_addr_vendor_file /var/lib/bluetooth/board-address; then
+        echo "Failed to copy $bt_addr_vendor_file."
         exit 1
     fi
 elif [ "$(getprop persist.vendor.service.bdroid.bdaddr)" != "" ]; then


### PR DESCRIPTION
The Pixel 3a's vendor prefers to store the BT MAC in a different property, namely "ro.vendor.bt.bdaddr_path". Take this into account without requiring modifications to the Android-/Halium-side init.rc bootup scripts.